### PR TITLE
fixed 'gulp deploy'

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version 4.2.2
+    version 6.11.2
 general:
   branches:
     only:

--- a/gulp/build.js
+++ b/gulp/build.js
@@ -18,9 +18,4 @@ gulp.task('compile', ['clean'], () => {
     .pipe(gulp.dest(opt.destDir.css));
 });
 
-// gulp.task('dest', ['clean'], () => {
-//   gulp.src(`${opt.srcDir.root}/**/*`)
-//     .pipe(gulp.dest(opt.destDir.root));
-// });
-
 gulp.task('clean', shell.task([`rm -rf ${opt.dirName.dest}`]));

--- a/gulp/deploy.js
+++ b/gulp/deploy.js
@@ -1,11 +1,10 @@
-let gulp = require('gulp');
-let awspublish = require('gulp-awspublish');
+import gulp from 'gulp';
+import awspublish from 'gulp-awspublish';
 import opt from './options';
+import shell from 'gulp-shell';
 
 
-gulp.task('deploy', ['build']);
-
-gulp.task('deploy', () => {
+gulp.task('deploy', ['wait'], () => {
   let publisher = awspublish.create({
     "params": {
       "Bucket": "s3website-study"
@@ -18,3 +17,5 @@ gulp.task('deploy', () => {
     .pipe(publisher.sync())
     .pipe(awspublish.reporter());
 });
+
+gulp.task('wait', ['build'], shell.task(['sleep 5']));


### PR DESCRIPTION
- Changes
    - `gulp deploy` で失敗していたので修正
        - どうやら `gulp build` で `public` フォルダ以下を作成し直した直後だと失敗するっぽいので、sleepする処理を追加。