### PR TITLE
fixed node version of circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.11.2
+    version: 6.1.0
 general:
   branches:
     only:


### PR DESCRIPTION
- Changes
    - `circle.yml` で指定している node のバージョンを circle ci の ubuntu 14 に事前インストールされている node のバーションに合わせるよう修正
     [node versions that are pre installed in ubuntu 14](https://circleci.com/docs/1.0/build-image-trusty/#nodejs)