### PR TITLE
fixed to specify npm version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
-    version: 6.1.0
+    version: 6.11.2
+  post:
+    - npm install -g npm@5.3
 general:
   branches:
     only:


### PR DESCRIPTION
- Changes
  - circle ci で node 6 をインストールしてるにもかかわらず npm のバージョンが古かったので、 npm のバージョンを指定してインストールするよう修正
  [npmのバージョン指定方法](http://qiita.com/inuscript/items/d2c87e076595f801b44b)

TODO: ちゃんと `circle.yml` の書き方を勉強しなくては。。。